### PR TITLE
Update and rename Environment.yml to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,5 +21,4 @@ dependencies:
   - simpeg=0.23.0
   - sympy=1.13.3
   - pandas
-  - pip:
    


### PR DESCRIPTION
I deleted a line from the environment file that I thought might have caused it to fail in my binder.org, now it is working.